### PR TITLE
Initial proposal for contributing guidelines for CLARIAH interest groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+CLARIAH Interest Group Contribution Guidelines
+================================================
+
+1. All relevant documents and other group output is gathered in this **central** and **public git repository** in the [CLARIAH](https://github.com/CLARIAH) github group.
+    - This ensures everything can be found in one place and is under proper version control and that everybody
+      is free to use the tools they prefer to edit the contents.
+    - This provides transparency and accountability.
+    - If there are relevant external resources then they should be **linked** from one or more documents this repository, a URL in relevant document will do.
+    - If the output of the group consists of custom-made software then that will be hosted in its
+      own separate repository and will be linked to from one of more documents in this repository.
+    - Keep documents in **plain text** as much as possible, or more specifically: use [Markdown](https://guides.github.com/features/mastering-markdown/) syntax and always use the UTF-8 character encoding. Prevent proprietary closed formats as much as possible.
+2. Group discussion takes place primarily through the **issue tracker** associated with this repository.
+    - Discussion is **public** and **open** to group members and non-group members alike (including partners outside of CLARIAH).
+    - All issues/tickets should ideally have a well-defined and limited scope; make multiple issues if you want to address multiple points.
+    - People who prefer to use their e-mail client can simply reply to the issue notifications received by mail (take
+        not of the next point)
+3. Group members should make sure to **watch** this repository (click the watch button) to receive notifications on important activity.
+4. Group membership is **open** to anybody with an interest in what we are doing and with some relationship to CLARIAH.
+5. Please submit significant contributions as [Pull Requests](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/creating-an-issue-or-pull-request). This automatically opens up a thread for **discussion and peer review** of your contributions and will notify all group members. The group coordinator can finally **approve and merge** your contributions.
+    - This may be overkill for small edits, in which case direct push access is a more adequate solution.
+6. There is a [text-based chat channel on Gitter.im](https://gitter.im/CLARIAH/home) where group members (of all interest groups) can gather and communicate in a more direct and informal manner. Everybody is welcome!


### PR DESCRIPTION
This is a proposal for some generic **contribution guidelines** to structure the way interest groups are run and contributions are made.  Although this proposal is made for the IG-Annotation group (@marijnkoolen was simply the first to take the initiative and actually start the group), it is not group-specific and would also be an applicable proposal for other interest groups.

In my opinion, it would help greatly if all CLARIAH interest groups are organised in a similar fashion rather than they each do their own thing, so people can more easily join and participate in multiple groups, and the groups can more easily see what the other groups are doing. I think establishing some clear and common platforms and communication mechanisms are essential to the success of the groups. In some initial discussion for the IG-Annotation group we opted for the CLARIAH Github group as a logical platform.

What I would like to explicitly avoid, is the scenario where we end up having some a group A that uses a Dropbox, group B with a google drive or plethora of widely scattered google docs, group C with a surfsara drive, and god-forbid a group D where the people just mail back and forth Word documents with nasty version numbers in the filenames... and none of the groups having access to each-other's resources and discussions!

This is just an initial proposal and hopefully gets the discussion started, so all feedback and comments are more than welcome! 

